### PR TITLE
Make looping coroutines backed by a notifier

### DIFF
--- a/core/src/main/kotlin/org/ghrobotics/lib/utils/CoroutineUtils.kt
+++ b/core/src/main/kotlin/org/ghrobotics/lib/utils/CoroutineUtils.kt
@@ -5,32 +5,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
-fun CoroutineScope.launchFrequency(
-    frequency: Int = 50,
-    context: CoroutineContext = EmptyCoroutineContext,
-    start: CoroutineStart = CoroutineStart.DEFAULT,
-    block: suspend CoroutineScope.() -> Unit
-): Job {
-    if (frequency <= 0) throw IllegalArgumentException("Frequency cannot be lower then 1!")
-    return launch(context, start) {
-        loopFrequency(frequency, block)
-    }
-}
 
-suspend fun CoroutineScope.loopFrequency(
-    frequency: Int = 50,
-    block: suspend CoroutineScope.() -> Unit
-) {
-    val timeBetweenUpdate = TimeUnit.SECONDS.toNanos(1) / frequency
-    // Stores when the next update should happen
-    var nextNS = System.nanoTime() + timeBetweenUpdate
-    while (isActive) {
-        block(this)
-        val delayNeeded = nextNS - System.nanoTime()
-        nextNS += timeBetweenUpdate
-        delay(delayNeeded / 1000000L)
-    }
-}
 
 inline fun disposableHandle(crossinline block: () -> Unit) = object : DisposableHandle {
     override fun dispose() {

--- a/wpi/src/main/kotlin/org/ghrobotics/lib/utils/WpiCoroutineUtils.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/utils/WpiCoroutineUtils.kt
@@ -1,0 +1,32 @@
+package org.ghrobotics.lib.utils
+
+import kotlinx.coroutines.*
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+fun CoroutineScope.launchFrequency(
+        frequency: Int = 50,
+        context: CoroutineContext = EmptyCoroutineContext,
+        start: CoroutineStart = CoroutineStart.DEFAULT,
+        block: suspend CoroutineScope.() -> Unit
+): Job {
+    if (frequency <= 0) throw IllegalArgumentException("Frequency cannot be lower then 1!")
+    return launch(context, start) {
+        loopFrequency(frequency, block)
+    }
+}
+
+suspend fun CoroutineScope.loopFrequency(
+    frequency: Int = 50,
+    block: suspend CoroutineScope.() -> Unit
+) {
+
+    val notifier = FalconNotifier(frequency)
+    notifier.updateAlarm()
+
+    while (isActive) {
+        notifier.waitForAlarm()
+        block(this)
+        notifier.updateAlarm()
+    }
+}

--- a/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/FalconNotifier.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/FalconNotifier.kt
@@ -1,0 +1,61 @@
+package org.ghrobotics.lib.utils
+
+import edu.wpi.first.hal.NotifierJNI
+import edu.wpi.first.wpilibj.Timer
+import edu.wpi.first.wpilibj.Notifier
+import org.ghrobotics.lib.mathematics.units.Time
+import org.ghrobotics.lib.mathematics.units.second
+import java.util.concurrent.TimeUnit
+
+/**
+ * A minimal wrapper over FPGA notifier alarms for periodic behaviour
+ *
+ * Unlike wpilib's [Notifier], this alarm does not spawn a new thread, nor does it take a task to run.
+ * Rather it provides the functionality for FPGA-backed timing, and leaves task execution to the caller
+ */
+class FalconNotifier(frequency: Int) : AutoCloseable {
+
+    /**
+     * The period of this alarm in microseconds
+     */
+    private val period = TimeUnit.SECONDS.toMicros(1) / frequency
+
+    /**
+     * The JNI handle for this alarm
+     */
+    private val notifier = NotifierJNI.initializeNotifier()
+
+    private var closed = false
+
+    /**
+     * Updates the notifier alarm. Should be called when the alarm is tripped to
+     * reset the ticker
+     */
+    fun updateAlarm(currentTime: Time = Timer.getFPGATimestamp().second) {
+        if (closed) {
+            throw IllegalStateException("updateAlarm() called on a disposed notifier! Check usages of close() for the relevant instance")
+        }
+        NotifierJNI.updateNotifierAlarm(notifier, (currentTime.microsecond + period).toLong())
+    }
+
+    /**
+     * Blocks the thread until the notifier alarm trips.
+     */
+    fun waitForAlarm(): Long {
+        if (closed) {
+            throw IllegalStateException("waitForAlarm() called on a disposed notifier! Check usages of close() for the relevant instance")
+        }
+        return NotifierJNI.waitForNotifierAlarm(notifier)
+    }
+
+    /**
+     * Disposes of the internal notifier handle, and **invalidates** the associated [FalconNotifier]
+     *
+     * This should be the last function called before the instance goes out of scope for garbage collection.
+     * Alarm resetting should not be done if the notifier has been closed.
+     */
+    override fun close() {
+        closed = true
+        NotifierJNI.cleanNotifier(notifier)
+    }
+}


### PR DESCRIPTION
* launchFrequency moved into wpi subproject, as it now depends on the
pressence of a notifier
* Rather than using delay(), which is backed by Thread.sleep, change
coroutine looping function to use a notifier. Notifiers are much more
precise for timing. In testing, the standard deviation of delta times
for notifier-back loops is 4 orders of magnitude smaller than that of
Thread.sleep backed loops
* Add FalconNotifier, which acts similar to Notifier, except lower
level. Provides a minimal wrapper over HAL calls and allows the user to
use the notifier as they see fit