### PR TITLE
Make the Spark MAX's PID controller public

### DIFF
--- a/vendorREV/src/main/kotlin/org/ghrobotics/lib/motors/rev/FalconMAX.kt
+++ b/vendorREV/src/main/kotlin/org/ghrobotics/lib/motors/rev/FalconMAX.kt
@@ -14,7 +14,7 @@ class FalconMAX<T : SIUnit<T>>(
     val model: NativeUnitModel<T>
 ) : AbstractFalconMotor<T>() {
 
-    private val controller: CANPIDController = canSparkMax.pidController
+    val controller: CANPIDController = canSparkMax.pidController
     override val encoder = FalconMAXEncoder(canSparkMax.encoder, model)
 
     override val voltageOutput: Double


### PR DESCRIPTION
Without making the visibility public or writing a wrapper around the controller, there is no way to change SPARK MAX PID settings (I think)