### PR TITLE
 Create BoundedHIDAxisSource, boundedAxisButton, greaterThanAxisButton… 

### DIFF
--- a/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/FalconHID.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/FalconHID.kt
@@ -9,7 +9,7 @@ fun <T : GenericHID> T.mapControls(
     block: FalconHIDBuilder<T>.() -> Unit
 ) = FalconHIDBuilder(this).also(block).build()
 
-class FalconHIDBuilder<T : GenericHID>(private val genericHID: T) {
+class FalconHIDBuilder<T : GenericHID>(val genericHID: T) {
     private val controlBuilders = mutableListOf<FalconHIDControlBuilder>()
     private val stateControlBuilders = mutableMapOf<BooleanSource, FalconHIDBuilder<T>>()
 

--- a/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/FalconHID.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/FalconHID.kt
@@ -28,21 +28,20 @@ class FalconHIDBuilder<T : GenericHID>(val genericHID: T) {
             axisId: Int,
             threshold: Double = HIDButton.DEFAULT_THRESHOLD,
             block: FalconHIDButtonBuilder.() -> Unit = {}
-    ) = boundedAxisButton(axisId, threshold, -1.0, 0.0)
+    ) = boundedAxisButton(axisId, threshold, -1.0..0.0, block)
 
     fun greaterThanAxisButton(
             axisId: Int,
             threshold: Double = HIDButton.DEFAULT_THRESHOLD,
             block: FalconHIDButtonBuilder.() -> Unit = {}
-    ) = boundedAxisButton(axisId, threshold, 0.0, 1.0)
+    ) = boundedAxisButton(axisId, threshold, 0.0..1.0, block)
 
     fun boundedAxisButton(
             axisId: Int,
             threshold: Double = HIDButton.DEFAULT_THRESHOLD,
-            minValue: Double,
-            maxValue: Double,
+            range: ClosedFloatingPointRange<Double>,
             block: FalconHIDButtonBuilder.() -> Unit = {}
-    ) = button(BoundedHIDAxisSource(genericHID, axisId, minValue, maxValue), threshold, block)
+    ) = button(BoundedHIDAxisSource(genericHID, axisId, range), threshold, block)
 
     fun pov(angle: Int, block: FalconHIDButtonBuilder.() -> Unit = {}) = pov(0, angle, block)
     fun pov(pov: Int, angle: Int, block: FalconHIDButtonBuilder.() -> Unit = {}) =

--- a/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/FalconHID.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/FalconHID.kt
@@ -24,6 +24,26 @@ class FalconHIDBuilder<T : GenericHID>(val genericHID: T) {
         block: FalconHIDButtonBuilder.() -> Unit = {}
     ) = button(HIDAxisSource(genericHID, axisId), threshold, block)
 
+    fun lessThanAxisButton(
+            axisId: Int,
+            threshold: Double = HIDButton.DEFAULT_THRESHOLD,
+            block: FalconHIDButtonBuilder.() -> Unit = {}
+    ) = boundedAxisButton(axisId, threshold, -1.0, 0.0)
+
+    fun greaterThanAxisButton(
+            axisId: Int,
+            threshold: Double = HIDButton.DEFAULT_THRESHOLD,
+            block: FalconHIDButtonBuilder.() -> Unit = {}
+    ) = boundedAxisButton(axisId, threshold, 0.0, 1.0)
+
+    fun boundedAxisButton(
+            axisId: Int,
+            threshold: Double = HIDButton.DEFAULT_THRESHOLD,
+            minValue: Double,
+            maxValue: Double,
+            block: FalconHIDButtonBuilder.() -> Unit = {}
+    ) = button(BoundedHIDAxisSource(genericHID, axisId, minValue, maxValue), threshold, block)
+
     fun pov(angle: Int, block: FalconHIDButtonBuilder.() -> Unit = {}) = pov(0, angle, block)
     fun pov(pov: Int, angle: Int, block: FalconHIDButtonBuilder.() -> Unit = {}) =
         button(HIDPOVSource(genericHID, pov, angle), block = block)

--- a/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/HIDSource.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/HIDSource.kt
@@ -26,10 +26,9 @@ class HIDAxisSource(
 class BoundedHIDAxisSource(
         private val genericHID: GenericHID,
         private val axisId: Int,
-        private val minValue: Double,
-        private val maxValue: Double
+        private val range: ClosedFloatingPointRange<Double>
 ) : HIDSource {
-    override fun invoke() = min(max(genericHID.getRawAxis(axisId), minValue), maxValue)
+    override fun invoke() = genericHID.getRawAxis(axisId).coerceIn(range)
 }
 
 class HIDPOVSource(

--- a/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/HIDSource.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/HIDSource.kt
@@ -1,8 +1,11 @@
 package org.ghrobotics.lib.wrappers.hid
 
 import edu.wpi.first.wpilibj.GenericHID
+import org.ghrobotics.lib.mathematics.max
+import org.ghrobotics.lib.mathematics.min
 import org.ghrobotics.lib.utils.BooleanSource
 import org.ghrobotics.lib.utils.Source
+import org.ghrobotics.lib.utils.safeRangeTo
 
 class HIDButtonSource(
     private val genericHID: GenericHID,
@@ -18,6 +21,15 @@ class HIDAxisSource(
     private val axisId: Int
 ) : HIDSource {
     override fun invoke() = genericHID.getRawAxis(axisId)
+}
+
+class BoundedHIDAxisSource(
+        private val genericHID: GenericHID,
+        private val axisId: Int,
+        private val minValue: Double,
+        private val maxValue: Double
+) : HIDSource {
+    override fun invoke() = min(max(genericHID.getRawAxis(axisId), minValue), maxValue)
 }
 
 class HIDPOVSource(

--- a/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/HIDSource.kt
+++ b/wpi/src/main/kotlin/org/ghrobotics/lib/wrappers/hid/HIDSource.kt
@@ -1,11 +1,8 @@
 package org.ghrobotics.lib.wrappers.hid
 
 import edu.wpi.first.wpilibj.GenericHID
-import org.ghrobotics.lib.mathematics.max
-import org.ghrobotics.lib.mathematics.min
 import org.ghrobotics.lib.utils.BooleanSource
 import org.ghrobotics.lib.utils.Source
-import org.ghrobotics.lib.utils.safeRangeTo
 
 class HIDButtonSource(
     private val genericHID: GenericHID,


### PR DESCRIPTION
The BoundedHIDAxisSource will only return axis values bounded to the given minimum and maximum. This can be used to split a joystick axis into two (or more) different buttons.

The wrapped genericHID passed to FalconHIDBuilder has also been increased to allow more flexible creation of unique control schemes in subclasses or extension functions.